### PR TITLE
feat: New parameters for Client websocket packet data size

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,2 +1,1 @@
-1. The client side now supports wss (WebSocket secured) connections.
-2. Fix client-side default port for ws and wss connections.
+1. New parameters for Socket data length

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,1 +1,2 @@
 1. New parameters for Socket data length
+2. Add SNI support

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ This mod runs standalone and does not have any dependency.
 ## Configuration
 The configuration of this mod is passed in the "system properties". You can use `-D` in the JVM command line to pass such options.
 
-| Property Key           | Type    | Usage                                                                                                                                                                                        | Side          | Default | Example |
-|------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------|---------|
-| wsmc.disableVanillaTCP | boolean | Disable vanilla TCP login and server status.                                                                                                                                                 | Server        | false   | true    |
-| wsmc.wsmcEndpoint      | string  | Set the WebSocket Endpoint for Minecraft login and server status. If this property does not exist, a client can join the game via ANY WebSocket Endpoint. Must start with /, case-sensitive. | Server        | Not set | /mc     |
-| wsmc.debug             | boolean | Show debug logs.                                                                                                                                                                             | Server Client | false   | true    |
-| wsmc.dumpBytes         | boolean | Dump raw WebSocket binary frames. Work only if `wsmc.debug` is set to `true`.                                                                                                                | Server Client | false   | true    |
+| Property Key               | Type     | Usage                                                                                                                                                                                        | Side          | Default | Example  |
+|----------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------|----------|
+| wsmc.disableVanillaTCP     | boolean  | Disable vanilla TCP login and server status.                                                                                                                                                 | Server        | false   | true     |
+| wsmc.wsmcEndpoint          | string   | Set the WebSocket Endpoint for Minecraft login and server status. If this property does not exist, a client can join the game via ANY WebSocket Endpoint. Must start with /, case-sensitive. | Server        | Not set | /mc      |
+| wsmc.debug                 | boolean  | Show debug logs.                                                                                                                                                                             | Server Client | false   | true     |
+| wsmc.dumpBytes             | boolean  | Dump raw WebSocket binary frames. Work only if `wsmc.debug` is set to `true`.                                                                                                                | Server Client | false   | true     |
+| wsmc.maxFramePayloadLength | string   | Maximum allowable frame payload length. Setting this value to your modpack's requirement else Netty will throw error "Max frame length of x has been exceeded".                              | Client        | 65536   | 65536    |
 
 ## Dependencies
 ### Forge Version

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The configuration of this mod is passed in the "system properties". You can use 
 | wsmc.wsmcEndpoint          | string   | Set the WebSocket Endpoint for Minecraft login and server status. If this property does not exist, a client can join the game via ANY WebSocket Endpoint. Must start with /, case-sensitive. | Server        | Not set | /mc      |
 | wsmc.debug                 | boolean  | Show debug logs.                                                                                                                                                                             | Server Client | false   | true     |
 | wsmc.dumpBytes             | boolean  | Dump raw WebSocket binary frames. Work only if `wsmc.debug` is set to `true`.                                                                                                                | Server Client | false   | true     |
-| wsmc.maxFramePayloadLength | string   | Maximum allowable frame payload length. Setting this value to your modpack's requirement else Netty will throw error "Max frame length of x has been exceeded".                              | Client        | 65536   | 65536    |
+| wsmc.maxFramePayloadLength | string   | Maximum allowable frame payload length. Setting this value to your modpack's requirement else Netty will throw error "Max frame length of x has been exceeded".                              | Server Client | 65536   | 65536    |
 
 ## Dependencies
 ### Forge Version

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.daemon=false
 	fabric_version=0.89.3+1.20.2
 
 # Mod Properties
-	mod_version = 0.4
+	mod_version = 0.5
 	dev_group = wsmc
 	archives_base_name = wsmc
 

--- a/src/main/java/wsmc/HttpServerHandler.java
+++ b/src/main/java/wsmc/HttpServerHandler.java
@@ -22,6 +22,12 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
 	public final static String wsmcEndpoint = System.getProperty("wsmc.wsmcEndpoint", null);
 
 	/**
+	 * This will set your maximum allowable frame payload length.
+	 * Setting this value for big modpack.
+	 */
+	public final static String maxFramePayloadLength = System.getProperty("wsmc.maxFramePayloadLength", "65536");
+
+	/**
 	 * This will be called when a WebSocket upgrade is received.
 	 * Note that this does NOT guarantee a success WebSocket handshake.
 	 */
@@ -73,9 +79,18 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
 
 				WSMC.debug("Opened Channel: " + ctx.channel());
 
+				int maxFramePayloadLength = 65536;
+
+				try {
+					maxFramePayloadLength = Integer.parseInt(HttpServerHandler.maxFramePayloadLength);
+				} catch (Exception e){
+					WSMC.debug("Unable to parse maxFramePayloadLength, value: " + HttpServerHandler.maxFramePayloadLength);
+				}
+
+				System.out.println("maxFramePayloadLength: " + maxFramePayloadLength);
 				// Do the Handshake to upgrade connection from HTTP to WebSocket protocol
 				WebSocketServerHandshakerFactory wsFactory =
-						new WebSocketServerHandshakerFactory(url, null, true);
+							new WebSocketServerHandshakerFactory(url, null, true, maxFramePayloadLength);
 				WebSocketServerHandshaker handshaker = wsFactory.newHandshaker(httpRequest);
 
 				if (handshaker == null) {

--- a/src/main/java/wsmc/client/WebSocketClientHandler.java
+++ b/src/main/java/wsmc/client/WebSocketClientHandler.java
@@ -36,7 +36,7 @@ public class WebSocketClientHandler extends WebSocketHandler {
 	 * This will set your maximum allowable frame payload length.
 	 * Setting this value for big modpack.
 	 */
-	public final static String maxFramePayloadLength = System.getProperty("wsmc.maxFramePayloadLength ", "65536");
+	public final static String maxFramePayloadLength = System.getProperty("wsmc.maxFramePayloadLength", "65536");
 
 	public WebSocketClientHandler(URI uri) {
 		super("S->C", "C->S");

--- a/src/main/java/wsmc/client/WebSocketClientHandler.java
+++ b/src/main/java/wsmc/client/WebSocketClientHandler.java
@@ -32,14 +32,28 @@ public class WebSocketClientHandler extends WebSocketHandler {
 	private final WebSocketClientHandshaker handshaker;
 	private ChannelPromise handshakeFuture;
 
+	/**
+	 * This will set your maximum allowable frame payload length.
+	 * Setting this value for big modpack.
+	 */
+	public final static String maxFramePayloadLength = System.getProperty("wsmc.maxFramePayloadLength ", "65536");
+
 	public WebSocketClientHandler(URI uri) {
 		super("S->C", "C->S");
+
+		int maxFramePayloadLength = 65536;
+
+		try {
+			maxFramePayloadLength = Integer.parseInt(WebSocketClientHandler.maxFramePayloadLength);
+		} catch (Exception e){
+			WSMC.debug("Unable to parse maxFramePayloadLength, value: " + WebSocketClientHandler.maxFramePayloadLength);
+		}
 
         // Connect with V13 (RFC 6455 aka HyBi-17). You can change it to V08 or V00.
         // If you change it to V00, ping is not supported and remember to change
         // HttpResponseDecoder to WebSocketHttpResponseDecoder in the pipeline.
 		this.handshaker = WebSocketClientHandshakerFactory.newHandshaker(uri,
-				WebSocketVersion.V13, null, true, new DefaultHttpHeaders());
+				WebSocketVersion.V13, null, true, new DefaultHttpHeaders(), maxFramePayloadLength);
 	}
 
 	public static WebSocketClientHandler fromServerData(IWebSocketServerAddress wsInfo) {


### PR DESCRIPTION
# Description

When you playing with big modpack , the Netty will throw `Max frame length of 65536 has been exceeded.`. So you need a way to change websocket max packet size via config, since you don't use Forge Config so I add the input via Parameter
