### PR TITLE
feat: Backport to 1.20.1 Forge

### DIFF
--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -4,11 +4,11 @@ org.gradle.daemon=false
 
 # Common Properties
 	# The Minecraft version in the development environment
-	minecraft_version=1.20.2
+	minecraft_version=1.20.1
 	# The minimum minecraft version (inclusive) to run this Mod
-	minecraft_version_min=1.20.2
+	minecraft_version_min=1.20.1
 	# The maximum minecraft version (exclusive) to run this Mod
-	minecraft_version_max=1.21
+	minecraft_version_max=1.20.2
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html	

--- a/forge/gradle.properties
+++ b/forge/gradle.properties
@@ -4,10 +4,10 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # The Forge version must agree with the Minecraft version to get a valid artifact
-forge_version=48.0.1
+forge_version=47.0.1
 # The Forge version range can use any version of Forge as bounds or match the loader version range
-forge_version_range=[48,)
+forge_version_range=[47,)
 # The loader version range can only use the major version of Forge/FML as bounds
-loader_version_range=[48,)
+loader_version_range=[47,)
 
 mixin_version = 0.8.5

--- a/src/main/java/wsmc/mixin/MixinConnection.java
+++ b/src/main/java/wsmc/mixin/MixinConnection.java
@@ -12,7 +12,6 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import io.netty.handler.codec.http.HttpRequest;
 import net.minecraft.network.Connection;
-import net.minecraft.util.SampleLogger;
 
 import wsmc.IConnectionEx;
 import wsmc.IWebSocketServerAddress;
@@ -33,7 +32,7 @@ public class MixinConnection implements IConnectionEx {
 	@Inject(method = "connectToServer", locals = LocalCapture.CAPTURE_FAILHARD, at = @At(value = "INVOKE",
 			target = "Lnet/minecraft/network/Connection;connect(Ljava/net/InetSocketAddress;ZLnet/minecraft/network/Connection;)Lio/netty/channel/ChannelFuture;"))
 	private static void beforeCallConnect(InetSocketAddress socketAddress, boolean preferEPoll,
-			SampleLogger logger, CallbackInfoReturnable<Connection> callback, Connection connection) {
+			CallbackInfoReturnable<Connection> callback, Connection connection) {
 		IWebSocketServerAddress wsAddress = IConnectionEx.connectToServerArg.pop();
 		IConnectionEx con = (IConnectionEx) connection;
 		con.setWsInfo(wsAddress);

--- a/src/main/java/wsmc/mixin/MixinServerStatusPinger.java
+++ b/src/main/java/wsmc/mixin/MixinServerStatusPinger.java
@@ -17,8 +17,8 @@ import wsmc.IWebSocketServerAddress;
 @Debug(export = true)
 @Mixin(ServerStatusPinger.class)
 public class MixinServerStatusPinger {
-	@Inject(method = "pingServer", locals = LocalCapture.CAPTURE_FAILHARD, at = @At(value = "INVOKE",
-			target = "Lnet/minecraft/network/Connection;connectToServer(Ljava/net/InetSocketAddress;ZLnet/minecraft/util/SampleLogger;)Lnet/minecraft/network/Connection;"))
+	@Inject(method = "pingServer", locals = LocalCapture.CAPTURE_FAILHARD, require = 1, at = @At(value = "INVOKE",
+			target = "Lnet/minecraft/network/Connection;connectToServer(Ljava/net/InetSocketAddress;Z)Lnet/minecraft/network/Connection;"))
 	public void beforeCallConnect(ServerData serverData, Runnable runnable, CallbackInfo callback,
 			ServerAddress serverAddress) {
 		IWebSocketServerAddress wsAddress = IWebSocketServerAddress.from(serverAddress);


### PR DESCRIPTION
# Description

This change allow Minecraft version 1.20.1 (and possible 1.20.0) to use the mod .

## Note

Since I can't add new branch , this suppose go to Branch 1.20.1 if possible